### PR TITLE
feat: switch app to black and white theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Rize.io-inspired Productivity Tracker</title>
   </head>
-  <body>
+  <body class="bg-black text-white filter grayscale">
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,10 +13,10 @@ function App() {
 
   if (loading) {
     return (
-      <div className="min-h-screen bg-gray-100 flex items-center justify-center">
+      <div className="min-h-screen bg-black flex items-center justify-center">
         <div className="text-center">
-          <div className="w-8 h-8 border-2 border-indigo-600 border-t-transparent rounded-full animate-spin mx-auto mb-4" />
-          <p className="text-gray-600">Loading...</p>
+          <div className="w-8 h-8 border-2 border-white border-t-transparent rounded-full animate-spin mx-auto mb-4" />
+          <p className="text-white">Loading...</p>
         </div>
       </div>
     );
@@ -37,22 +37,22 @@ function App() {
       case 'goals':
         return (
           <div className="p-6">
-            <h1 className="text-2xl font-bold text-gray-900 mb-4">Goals</h1>
-            <p className="text-gray-600">Goal tracking feature coming soon...</p>
+            <h1 className="text-2xl font-bold text-white mb-4">Goals</h1>
+            <p className="text-gray-400">Goal tracking feature coming soon...</p>
           </div>
         );
       case 'analytics':
         return (
           <div className="p-6">
-            <h1 className="text-2xl font-bold text-gray-900 mb-4">Analytics</h1>
-            <p className="text-gray-600">Advanced analytics coming soon...</p>
+            <h1 className="text-2xl font-bold text-white mb-4">Analytics</h1>
+            <p className="text-gray-400">Advanced analytics coming soon...</p>
           </div>
         );
       case 'settings':
         return (
           <div className="p-6">
-            <h1 className="text-2xl font-bold text-gray-900 mb-4">Settings</h1>
-            <p className="text-gray-600">Settings panel coming soon...</p>
+            <h1 className="text-2xl font-bold text-white mb-4">Settings</h1>
+            <p className="text-gray-400">Settings panel coming soon...</p>
           </div>
         );
       default:

--- a/src/components/Activities.tsx
+++ b/src/components/Activities.tsx
@@ -1,8 +1,7 @@
 import React, { useState } from 'react';
-import { 
-  Globe, 
-  Monitor, 
-  Clock, 
+import {
+  Globe,
+  Monitor,
   Filter,
   Search,
   TrendingUp,
@@ -36,9 +35,9 @@ export function Activities({ userId }: ActivitiesProps) {
   };
 
   const getProductivityColor = (score: number) => {
-    if (score >= 4) return 'text-green-600 bg-green-100';
-    if (score >= 3) return 'text-yellow-600 bg-yellow-100';
-    return 'text-red-600 bg-red-100';
+    if (score >= 4) return 'text-gray-200 bg-gray-800';
+    if (score >= 3) return 'text-gray-400 bg-gray-800';
+    return 'text-gray-600 bg-gray-800';
   };
 
   const getProductivityIcon = (score: number) => {
@@ -64,23 +63,19 @@ export function Activities({ userId }: ActivitiesProps) {
     <div className="p-6 space-y-6">
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">Activity Tracking</h1>
-          <p className="text-gray-600">Monitor your digital activities and productivity</p>
+          <h1 className="text-2xl font-bold text-white">Activity Tracking</h1>
+          <p className="text-gray-400">Monitor your digital activities and productivity</p>
         </div>
         <div className="flex items-center gap-4">
           <div className="flex items-center gap-2">
-            <div className={`w-3 h-3 rounded-full ${isTracking ? 'bg-green-500' : 'bg-gray-400'}`} />
-            <span className="text-sm font-medium text-gray-700">
+            <div className={`w-3 h-3 rounded-full ${isTracking ? 'bg-gray-200' : 'bg-gray-600'}`} />
+            <span className="text-sm font-medium text-gray-300">
               {isTracking ? 'Tracking Active' : 'Tracking Paused'}
             </span>
           </div>
           <button
             onClick={isTracking ? stopTracking : startTracking}
-            className={`px-4 py-2 rounded-lg font-medium transition-colors ${
-              isTracking
-                ? 'bg-red-100 text-red-700 hover:bg-red-200'
-                : 'bg-green-100 text-green-700 hover:bg-green-200'
-            }`}
+            className="px-4 py-2 rounded-lg font-medium transition-colors bg-gray-800 text-white hover:bg-gray-700"
           >
             {isTracking ? 'Stop Tracking' : 'Start Tracking'}
           </button>
@@ -93,9 +88,9 @@ export function Activities({ userId }: ActivitiesProps) {
           .sort(([,a], [,b]) => b.totalTime - a.totalTime)
           .slice(0, 3)
           .map(([category, stats]) => (
-            <div key={category} className="bg-white rounded-xl border border-gray-200 p-6">
+            <div key={category} className="bg-gray-900 rounded-xl border border-gray-700 p-6">
               <div className="flex items-center justify-between mb-3">
-                <h3 className="font-semibold text-gray-900">{category}</h3>
+                <h3 className="font-semibold text-white">{category}</h3>
                 <div className={`px-2 py-1 rounded-full text-xs font-medium ${
                   getProductivityColor(stats.avgProductivity)
                 }`}>
@@ -104,12 +99,12 @@ export function Activities({ userId }: ActivitiesProps) {
               </div>
               <div className="space-y-2">
                 <div className="flex justify-between text-sm">
-                  <span className="text-gray-600">Total Time</span>
-                  <span className="font-medium">{formatDuration(stats.totalTime)}</span>
+                  <span className="text-gray-400">Total Time</span>
+                  <span className="font-medium text-white">{formatDuration(stats.totalTime)}</span>
                 </div>
                 <div className="flex justify-between text-sm">
-                  <span className="text-gray-600">Activities</span>
-                  <span className="font-medium">{stats.count}</span>
+                  <span className="text-gray-400">Activities</span>
+                  <span className="font-medium text-white">{stats.count}</span>
                 </div>
               </div>
             </div>
@@ -117,26 +112,26 @@ export function Activities({ userId }: ActivitiesProps) {
       </div>
 
       {/* Filters and Search */}
-      <div className="bg-white rounded-xl border border-gray-200 p-6">
+      <div className="bg-gray-900 rounded-xl border border-gray-700 p-6">
         <div className="flex flex-col sm:flex-row gap-4">
           <div className="flex-1">
             <div className="relative">
-              <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 w-5 h-5 text-gray-400" />
+              <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 w-5 h-5 text-gray-500" />
               <input
                 type="text"
                 placeholder="Search activities..."
                 value={searchTerm}
                 onChange={(e) => setSearchTerm(e.target.value)}
-                className="w-full pl-10 pr-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-transparent"
+                className="w-full pl-10 pr-4 py-2 border border-gray-700 rounded-lg focus:ring-2 focus:ring-gray-500 focus:border-transparent bg-black text-white placeholder-gray-500"
               />
             </div>
           </div>
           <div className="flex items-center gap-2">
-            <Filter className="w-5 h-5 text-gray-400" />
+            <Filter className="w-5 h-5 text-gray-500" />
             <select
               value={filter}
-              onChange={(e) => setFilter(e.target.value as any)}
-              className="border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-indigo-500 focus:border-transparent"
+              onChange={(e) => setFilter(e.target.value as 'all' | 'website' | 'application')}
+              className="border border-gray-700 rounded-lg px-3 py-2 focus:ring-2 focus:ring-gray-500 focus:border-transparent bg-black text-white"
             >
               <option value="all">All Activities</option>
               <option value="website">Websites</option>
@@ -147,30 +142,30 @@ export function Activities({ userId }: ActivitiesProps) {
       </div>
 
       {/* Activities List */}
-      <div className="bg-white rounded-xl border border-gray-200">
-        <div className="p-6 border-b border-gray-200">
-          <h2 className="text-lg font-semibold text-gray-900">Recent Activities</h2>
-          <p className="text-gray-600 text-sm">
+      <div className="bg-gray-900 rounded-xl border border-gray-700">
+        <div className="p-6 border-b border-gray-700">
+          <h2 className="text-lg font-semibold text-white">Recent Activities</h2>
+          <p className="text-gray-400 text-sm">
             Showing {filteredActivities.length} of {activities.length} activities
           </p>
         </div>
-        <div className="divide-y divide-gray-200">
+        <div className="divide-y divide-gray-700">
           {filteredActivities.slice(0, 20).map((activity) => {
             const ProductivityIcon = getProductivityIcon(activity.productivity_score);
             return (
-              <div key={activity.id} className="p-6 hover:bg-gray-50 transition-colors">
+              <div key={activity.id} className="p-6 hover:bg-gray-800 transition-colors">
                 <div className="flex items-center justify-between">
                   <div className="flex items-center gap-4">
-                    <div className="w-10 h-10 bg-gray-100 rounded-lg flex items-center justify-center">
+                    <div className="w-10 h-10 bg-gray-800 rounded-lg flex items-center justify-center">
                       {activity.type === 'website' ? (
-                        <Globe className="w-5 h-5 text-gray-600" />
+                        <Globe className="w-5 h-5 text-gray-300" />
                       ) : (
-                        <Monitor className="w-5 h-5 text-gray-600" />
+                        <Monitor className="w-5 h-5 text-gray-300" />
                       )}
                     </div>
                     <div>
-                      <h3 className="font-semibold text-gray-900">{activity.name}</h3>
-                      <div className="flex items-center gap-2 text-sm text-gray-500">
+                      <h3 className="font-semibold text-white">{activity.name}</h3>
+                      <div className="flex items-center gap-2 text-sm text-gray-400">
                         <span>{activity.category}</span>
                         {activity.url && (
                           <>
@@ -183,10 +178,10 @@ export function Activities({ userId }: ActivitiesProps) {
                   </div>
                   <div className="flex items-center gap-4">
                     <div className="text-right">
-                      <div className="font-semibold text-gray-900">
+                      <div className="font-semibold text-white">
                         {formatDuration(activity.duration)}
                       </div>
-                      <div className="text-sm text-gray-500">
+                      <div className="text-sm text-gray-400">
                         {new Date(activity.timestamp).toLocaleTimeString()}
                       </div>
                     </div>

--- a/src/components/AuthForm.tsx
+++ b/src/components/AuthForm.tsx
@@ -24,7 +24,7 @@ export function AuthForm() {
       if (error) {
         setError(error.message);
       }
-    } catch (err) {
+    } catch {
       setError('An unexpected error occurred');
     } finally {
       setLoading(false);
@@ -32,32 +32,32 @@ export function AuthForm() {
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 flex items-center justify-center p-4">
-      <div className="bg-white rounded-2xl shadow-xl p-8 w-full max-w-md">
+    <div className="min-h-screen bg-black flex items-center justify-center p-4">
+      <div className="bg-gray-900 text-white rounded-2xl shadow-xl p-8 w-full max-w-md">
         <div className="text-center mb-8">
-          <div className="w-16 h-16 bg-indigo-600 rounded-full flex items-center justify-center mx-auto mb-4">
-            <LogIn className="w-8 h-8 text-white" />
+          <div className="w-16 h-16 bg-white text-black rounded-full flex items-center justify-center mx-auto mb-4">
+            <LogIn className="w-8 h-8" />
           </div>
-          <h1 className="text-2xl font-bold text-gray-900 mb-2">
+          <h1 className="text-2xl font-bold mb-2">
             Welcome to RizeTracker
           </h1>
-          <p className="text-gray-600">
+          <p className="text-gray-400">
             Track your productivity and achieve your goals
           </p>
         </div>
 
         <form onSubmit={handleSubmit} className="space-y-6">
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-2">
+            <label className="block text-sm font-medium text-gray-300 mb-2">
               Email
             </label>
             <div className="relative">
-              <Mail className="absolute left-3 top-1/2 transform -translate-y-1/2 w-5 h-5 text-gray-400" />
+              <Mail className="absolute left-3 top-1/2 transform -translate-y-1/2 w-5 h-5 text-gray-500" />
               <input
                 type="email"
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
-                className="w-full pl-10 pr-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-transparent"
+                className="w-full pl-10 pr-4 py-3 border border-gray-700 rounded-lg focus:ring-2 focus:ring-gray-500 focus:border-transparent bg-black text-white placeholder-gray-500"
                 placeholder="Enter your email"
                 required
               />
@@ -65,16 +65,16 @@ export function AuthForm() {
           </div>
 
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-2">
+            <label className="block text-sm font-medium text-gray-300 mb-2">
               Password
             </label>
             <div className="relative">
-              <Lock className="absolute left-3 top-1/2 transform -translate-y-1/2 w-5 h-5 text-gray-400" />
+              <Lock className="absolute left-3 top-1/2 transform -translate-y-1/2 w-5 h-5 text-gray-500" />
               <input
                 type="password"
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
-                className="w-full pl-10 pr-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-transparent"
+                className="w-full pl-10 pr-4 py-3 border border-gray-700 rounded-lg focus:ring-2 focus:ring-gray-500 focus:border-transparent bg-black text-white placeholder-gray-500"
                 placeholder="Enter your password"
                 required
                 minLength={6}
@@ -83,15 +83,15 @@ export function AuthForm() {
           </div>
 
           {error && (
-            <div className="bg-red-50 border border-red-200 rounded-lg p-3">
-              <p className="text-red-600 text-sm">{error}</p>
+            <div className="bg-gray-800 border border-gray-600 rounded-lg p-3">
+              <p className="text-white text-sm">{error}</p>
             </div>
           )}
 
           <button
             type="submit"
             disabled={loading}
-            className="w-full bg-indigo-600 text-white py-3 px-4 rounded-lg hover:bg-indigo-700 focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed transition-colors flex items-center justify-center gap-2"
+            className="w-full bg-white text-black py-3 px-4 rounded-lg hover:bg-gray-200 focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed transition-colors flex items-center justify-center gap-2"
           >
             {loading ? (
               <div className="w-5 h-5 border-2 border-white border-t-transparent rounded-full animate-spin" />
@@ -107,7 +107,7 @@ export function AuthForm() {
         <div className="mt-6 text-center">
           <button
             onClick={() => setIsSignUp(!isSignUp)}
-            className="text-indigo-600 hover:text-indigo-700 text-sm font-medium"
+            className="text-white hover:text-gray-300 text-sm font-medium"
           >
             {isSignUp 
               ? 'Already have an account? Sign in' 

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -44,28 +44,28 @@ export function Dashboard({ userId }: DashboardProps) {
       title: 'Total Time Today',
       value: formatDuration(totalTimeToday),
       icon: Clock,
-      color: 'bg-blue-500',
+      color: 'bg-gray-700',
       change: '+12%'
     },
     {
       title: 'Productive Time',
       value: formatDuration(productiveTime),
       icon: TrendingUp,
-      color: 'bg-green-500',
+      color: 'bg-gray-700',
       change: '+8%'
     },
     {
       title: 'Focus Sessions',
       value: completedSessions.toString(),
       icon: Target,
-      color: 'bg-purple-500',
+      color: 'bg-gray-700',
       change: '+3'
     },
     {
       title: 'Productivity Score',
       value: `${productivityScore}/5`,
       icon: Activity,
-      color: 'bg-orange-500',
+      color: 'bg-gray-700',
       change: productivityScore >= 4 ? '+0.2' : '-0.1'
     }
   ];
@@ -78,7 +78,7 @@ export function Dashboard({ userId }: DashboardProps) {
           <p className="text-gray-300">Welcome back! Here's your productivity overview.</p>
         </div>
         <div className="flex items-center gap-2">
-          <div className={`w-3 h-3 rounded-full ${isTracking ? 'bg-green-500' : 'bg-gray-400'}`} />
+          <div className={`w-3 h-3 rounded-full ${isTracking ? 'bg-gray-200' : 'bg-gray-600'}`} />
           <span className="text-sm font-medium text-gray-300">
             {isTracking ? 'Tracking Active' : 'Tracking Paused'}
           </span>
@@ -95,7 +95,7 @@ export function Dashboard({ userId }: DashboardProps) {
                 <div className={`w-12 h-12 ${stat.color} rounded-lg flex items-center justify-center`}>
                   <Icon className="w-6 h-6 text-white" />
                 </div>
-                <span className="text-sm font-medium text-green-600">{stat.change}</span>
+                <span className="text-sm font-medium text-gray-400">{stat.change}</span>
               </div>
               <h3 className="text-2xl font-bold text-white mb-1">{stat.value}</h3>
               <p className="text-gray-300 text-sm">{stat.title}</p>
@@ -108,7 +108,7 @@ export function Dashboard({ userId }: DashboardProps) {
       {currentActivity && (
         <div className="bg-gray-900 rounded-xl border border-gray-700 p-6">
           <div className="flex items-center gap-3 mb-4">
-            <div className="w-3 h-3 bg-green-500 rounded-full animate-pulse" />
+            <div className="w-3 h-3 bg-gray-200 rounded-full animate-pulse" />
             <h2 className="text-lg font-semibold text-white">Current Activity</h2>
           </div>
           <div className="flex items-center justify-between">
@@ -125,7 +125,7 @@ export function Dashboard({ userId }: DashboardProps) {
                   <div
                     key={i}
                     className={`w-2 h-2 rounded-full ${
-                      i < currentActivity.productivity_score ? 'bg-green-500' : 'bg-gray-300'
+                      i < currentActivity.productivity_score ? 'bg-gray-200' : 'bg-gray-600'
                     }`}
                   />
                 ))}
@@ -144,8 +144,8 @@ export function Dashboard({ userId }: DashboardProps) {
             <div key={activity.id} className="flex items-center justify-between py-2">
               <div className="flex items-center gap-3">
                 <div className={`w-2 h-2 rounded-full ${
-                  activity.productivity_score >= 4 ? 'bg-green-500' :
-                  activity.productivity_score >= 3 ? 'bg-yellow-500' : 'bg-red-500'
+                  activity.productivity_score >= 4 ? 'bg-gray-200' :
+                  activity.productivity_score >= 3 ? 'bg-gray-400' : 'bg-gray-600'
                 }`} />
                 <div>
                   <p className="font-medium text-white">{activity.name}</p>
@@ -167,22 +167,22 @@ export function Dashboard({ userId }: DashboardProps) {
 
       {/* Quick Actions */}
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-        <div className="bg-gradient-to-r from-blue-500 to-blue-600 rounded-xl p-6 text-white">
+        <div className="bg-gray-800 rounded-xl p-6 text-white">
           <CheckCircle className="w-8 h-8 mb-3" />
           <h3 className="text-lg font-semibold mb-2">Start Focus Session</h3>
-          <p className="text-blue-100 text-sm">Begin a 25-minute Pomodoro session</p>
+          <p className="text-gray-400 text-sm">Begin a 25-minute Pomodoro session</p>
         </div>
-        
-        <div className="bg-gradient-to-r from-green-500 to-green-600 rounded-xl p-6 text-white">
+
+        <div className="bg-gray-800 rounded-xl p-6 text-white">
           <Target className="w-8 h-8 mb-3" />
           <h3 className="text-lg font-semibold mb-2">Set New Goal</h3>
-          <p className="text-green-100 text-sm">Create a productivity goal</p>
+          <p className="text-gray-400 text-sm">Create a productivity goal</p>
         </div>
-        
-        <div className="bg-gradient-to-r from-purple-500 to-purple-600 rounded-xl p-6 text-white">
+
+        <div className="bg-gray-800 rounded-xl p-6 text-white">
           <AlertCircle className="w-8 h-8 mb-3" />
           <h3 className="text-lg font-semibold mb-2">View Analytics</h3>
-          <p className="text-purple-100 text-sm">Check your progress trends</p>
+          <p className="text-gray-400 text-sm">Check your progress trends</p>
         </div>
       </div>
     </div>

--- a/src/components/FocusTimer.tsx
+++ b/src/components/FocusTimer.tsx
@@ -22,19 +22,19 @@ export function FocusTimer({ userId }: FocusTimerProps) {
   const modeConfig = {
     pomodoro: {
       label: 'Focus Time',
-      color: 'from-red-500 to-red-600',
+      color: 'from-gray-800 to-gray-900',
       icon: Clock,
       description: 'Time to focus and be productive'
     },
     short_break: {
       label: 'Short Break',
-      color: 'from-green-500 to-green-600',
+      color: 'from-gray-800 to-gray-900',
       icon: Coffee,
       description: 'Take a quick 5-minute break'
     },
     long_break: {
       label: 'Long Break',
-      color: 'from-blue-500 to-blue-600',
+      color: 'from-gray-800 to-gray-900',
       icon: Coffee,
       description: 'Enjoy a longer 15-minute break'
     }
@@ -48,8 +48,8 @@ export function FocusTimer({ userId }: FocusTimerProps) {
   return (
     <div className="p-6 max-w-2xl mx-auto">
       <div className="text-center mb-8">
-        <h1 className="text-2xl font-bold text-gray-900 mb-2">Focus Timer</h1>
-        <p className="text-gray-600">Stay focused with the Pomodoro Technique</p>
+        <h1 className="text-2xl font-bold text-white mb-2">Focus Timer</h1>
+        <p className="text-gray-400">Stay focused with the Pomodoro Technique</p>
       </div>
 
       {/* Timer Card */}
@@ -115,8 +115,8 @@ export function FocusTimer({ userId }: FocusTimerProps) {
       </div>
 
       {/* Mode Selector */}
-      <div className="bg-white rounded-xl border border-gray-200 p-6 mb-6">
-        <h3 className="text-lg font-semibold text-gray-900 mb-4">Timer Mode</h3>
+      <div className="bg-gray-900 rounded-xl border border-gray-700 p-6 mb-6">
+        <h3 className="text-lg font-semibold text-white mb-4">Timer Mode</h3>
         <div className="grid grid-cols-3 gap-3">
           {(Object.keys(modeConfig) as TimerMode[]).map((timerMode) => (
             <button
@@ -124,16 +124,16 @@ export function FocusTimer({ userId }: FocusTimerProps) {
               onClick={() => switchMode(timerMode)}
               className={`p-4 rounded-lg border-2 transition-colors ${
                 mode === timerMode
-                  ? 'border-indigo-500 bg-indigo-50 text-indigo-700'
-                  : 'border-gray-200 hover:border-gray-300'
+                  ? 'border-white bg-gray-800 text-white'
+                  : 'border-gray-700 hover:border-gray-500 text-gray-300'
               }`}
             >
               <div className="text-center">
                 <div className="font-semibold capitalize">
                   {timerMode.replace('_', ' ')}
                 </div>
-                <div className="text-sm text-gray-500">
-                  {timerMode === 'pomodoro' ? '25 min' : 
+                <div className="text-sm text-gray-400">
+                  {timerMode === 'pomodoro' ? '25 min' :
                    timerMode === 'short_break' ? '5 min' : '15 min'}
                 </div>
               </div>
@@ -143,20 +143,20 @@ export function FocusTimer({ userId }: FocusTimerProps) {
       </div>
 
       {/* Stats */}
-      <div className="bg-white rounded-xl border border-gray-200 p-6">
-        <h3 className="text-lg font-semibold text-gray-900 mb-4">Today's Progress</h3>
+      <div className="bg-gray-900 rounded-xl border border-gray-700 p-6">
+        <h3 className="text-lg font-semibold text-white mb-4">Today's Progress</h3>
         <div className="grid grid-cols-2 gap-6">
           <div className="text-center">
-            <div className="text-3xl font-bold text-indigo-600 mb-1">
+            <div className="text-3xl font-bold text-white mb-1">
               {completedSessions}
             </div>
-            <div className="text-gray-600">Completed Sessions</div>
+            <div className="text-gray-400">Completed Sessions</div>
           </div>
           <div className="text-center">
-            <div className="text-3xl font-bold text-green-600 mb-1">
+            <div className="text-3xl font-bold text-white mb-1">
               {Math.floor(completedSessions * 25 / 60)}h {(completedSessions * 25) % 60}m
             </div>
-            <div className="text-gray-600">Focus Time</div>
+            <div className="text-gray-400">Focus Time</div>
           </div>
         </div>
       </div>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -31,8 +31,8 @@ export function Sidebar({ activeTab, onTabChange }: SidebarProps) {
     <div className="w-64 bg-black text-white border-r border-gray-700 h-screen flex flex-col">
       <div className="p-6 border-b border-gray-700">
         <div className="flex items-center gap-3">
-          <div className="w-10 h-10 bg-indigo-600 rounded-lg flex items-center justify-center">
-            <BarChart3 className="w-6 h-6 text-white" />
+          <div className="w-10 h-10 bg-white text-black rounded-lg flex items-center justify-center">
+            <BarChart3 className="w-6 h-6" />
           </div>
           <div>
             <h1 className="text-xl font-bold text-white">RizeTracker</h1>


### PR DESCRIPTION
## Summary
- adopt a black and white visual style across the app
- restyle login, dashboard, timer and activity views for grayscale theme
- tweak sidebar branding to match monochrome palette

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6894ce2fc8a883219ceac8f34f8ceecb