### PR TITLE
feat: share activity tracker via context

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { Sidebar } from './components/Sidebar';
 import { Dashboard } from './components/Dashboard';
 import { FocusTimer } from './components/FocusTimer';
 import { Activities } from './components/Activities';
+import { ActivityTrackerProvider } from './hooks/useActivityTracker';
 
 function App() {
   const { user, loading } = useAuth();
@@ -33,7 +34,7 @@ function App() {
       case 'timer':
         return <FocusTimer userId={user.id} />;
       case 'activities':
-        return <Activities userId={user.id} />;
+        return <Activities />;
       case 'goals':
         return (
           <div className="p-6">
@@ -61,12 +62,14 @@ function App() {
   };
 
   return (
-    <div className="min-h-screen bg-black text-white flex">
-      <Sidebar activeTab={activeTab} onTabChange={setActiveTab} />
-      <main className="flex-1 overflow-auto">
-        {renderContent()}
-      </main>
-    </div>
+    <ActivityTrackerProvider userId={user.id}>
+      <div className="min-h-screen bg-black text-white flex">
+        <Sidebar activeTab={activeTab} onTabChange={setActiveTab} />
+        <main className="flex-1 overflow-auto">
+          {renderContent()}
+        </main>
+      </div>
+    </ActivityTrackerProvider>
   );
 }
 

--- a/src/components/Activities.tsx
+++ b/src/components/Activities.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useContext } from 'react';
 import {
   Globe,
   Monitor,
@@ -7,14 +7,14 @@ import {
   TrendingUp,
   TrendingDown
 } from 'lucide-react';
-import { useActivityTracker } from '../hooks/useActivityTracker';
+import { ActivityTrackerContext } from '../hooks/useActivityTracker';
 
-interface ActivitiesProps {
-  userId: string;
-}
-
-export function Activities({ userId }: ActivitiesProps) {
-  const { activities, isTracking, startTracking, stopTracking } = useActivityTracker(userId);
+export function Activities() {
+  const tracker = useContext(ActivityTrackerContext);
+  if (!tracker) {
+    throw new Error('ActivityTrackerContext not found');
+  }
+  const { activities, isTracking, startTracking, stopTracking } = tracker;
   const [filter, setFilter] = useState<'all' | 'website' | 'application'>('all');
   const [searchTerm, setSearchTerm] = useState('');
 

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -1,13 +1,13 @@
-import React from 'react';
-import { 
-  Clock, 
-  Target, 
-  TrendingUp, 
+import React, { useContext } from 'react';
+import {
+  Clock,
+  Target,
+  TrendingUp,
   Activity,
   CheckCircle,
   AlertCircle
 } from 'lucide-react';
-import { useActivityTracker } from '../hooks/useActivityTracker';
+import { ActivityTrackerContext } from '../hooks/useActivityTracker';
 import { usePomodoroTimer } from '../hooks/usePomodoroTimer';
 
 interface DashboardProps {
@@ -15,7 +15,11 @@ interface DashboardProps {
 }
 
 export function Dashboard({ userId }: DashboardProps) {
-  const { activities, currentActivity, isTracking } = useActivityTracker(userId);
+  const tracker = useContext(ActivityTrackerContext);
+  if (!tracker) {
+    throw new Error('ActivityTrackerContext not found');
+  }
+  const { activities, currentActivity, isTracking } = tracker;
   const { completedSessions } = usePomodoroTimer(userId);
 
   // Calculate today's stats

--- a/src/hooks/useActivityTracker.tsx
+++ b/src/hooks/useActivityTracker.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, createContext, ReactNode } from 'react';
 import { Activity } from '../types';
 import { dbHelpers } from '../lib/supabase';
 
@@ -102,4 +102,22 @@ export function useActivityTracker(userId: string | undefined) {
     startTracking,
     stopTracking,
   };
+}
+
+export type ActivityTrackerContextType = ReturnType<typeof useActivityTracker>;
+
+export const ActivityTrackerContext = createContext<ActivityTrackerContextType | null>(null);
+
+interface ActivityTrackerProviderProps {
+  userId: string | undefined;
+  children: ReactNode;
+}
+
+export function ActivityTrackerProvider({ userId, children }: ActivityTrackerProviderProps) {
+  const tracker = useActivityTracker(userId);
+  return (
+    <ActivityTrackerContext.Provider value={tracker}>
+      {children}
+    </ActivityTrackerContext.Provider>
+  );
 }


### PR DESCRIPTION
## Summary
- add `ActivityTrackerContext` and provider for shared state
- wrap app with `ActivityTrackerProvider` so pages use same tracker instance
- switch Dashboard and Activities to consume tracker from context

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6894d4cc64bc8321b77d31185be5b7fb