### PR TITLE
Add tasks feature

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { Sidebar } from './components/Sidebar';
 import { Dashboard } from './components/Dashboard';
 import { FocusTimer } from './components/FocusTimer';
 import { Activities } from './components/Activities';
+import { Tasks } from './components/Tasks';
 
 function App() {
   const { user, loading } = useAuth();
@@ -34,6 +35,8 @@ function App() {
         return <FocusTimer userId={user.id} />;
       case 'activities':
         return <Activities userId={user.id} />;
+      case 'tasks':
+        return <Tasks userId={user.id} />;
       case 'goals':
         return (
           <div className="p-6">

--- a/src/components/Activities.tsx
+++ b/src/components/Activities.tsx
@@ -1,8 +1,7 @@
 import React, { useState } from 'react';
-import { 
-  Globe, 
-  Monitor, 
-  Clock, 
+import {
+  Globe,
+  Monitor,
   Filter,
   Search,
   TrendingUp,
@@ -135,7 +134,9 @@ export function Activities({ userId }: ActivitiesProps) {
             <Filter className="w-5 h-5 text-gray-400" />
             <select
               value={filter}
-              onChange={(e) => setFilter(e.target.value as any)}
+              onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
+                setFilter(e.target.value as 'all' | 'website' | 'application')
+              }
               className="border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-indigo-500 focus:border-transparent"
             >
               <option value="all">All Activities</option>

--- a/src/components/AuthForm.tsx
+++ b/src/components/AuthForm.tsx
@@ -24,9 +24,9 @@ export function AuthForm() {
       if (error) {
         setError(error.message);
       }
-    } catch (err) {
-      setError('An unexpected error occurred');
-    } finally {
+      } catch {
+        setError('An unexpected error occurred');
+      } finally {
       setLoading(false);
     }
   };

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -3,8 +3,9 @@ import {
   BarChart3, 
   Clock, 
   Target, 
-  Activity, 
-  Settings, 
+  Activity,
+  ListChecks,
+  Settings,
   LogOut,
   Timer
 } from 'lucide-react';
@@ -22,6 +23,7 @@ export function Sidebar({ activeTab, onTabChange }: SidebarProps) {
     { id: 'dashboard', label: 'Dashboard', icon: BarChart3 },
     { id: 'timer', label: 'Focus Timer', icon: Timer },
     { id: 'activities', label: 'Activities', icon: Activity },
+    { id: 'tasks', label: 'Tasks', icon: ListChecks },
     { id: 'goals', label: 'Goals', icon: Target },
     { id: 'analytics', label: 'Analytics', icon: Clock },
     { id: 'settings', label: 'Settings', icon: Settings },

--- a/src/components/Tasks.tsx
+++ b/src/components/Tasks.tsx
@@ -1,0 +1,138 @@
+import React, { useState } from 'react';
+import { Plus, Trash, Pencil } from 'lucide-react';
+import { useTasks } from '../hooks/useTasks';
+import type { Task } from '../types';
+
+interface TasksProps {
+  userId: string;
+}
+
+export function Tasks({ userId }: TasksProps) {
+  const { tasks, addTask, updateTask, deleteTask } = useTasks(userId);
+  const [title, setTitle] = useState('');
+  const [dueDate, setDueDate] = useState('');
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editTitle, setEditTitle] = useState('');
+  const [editDueDate, setEditDueDate] = useState('');
+
+  const handleAdd = async () => {
+    if (!title.trim()) return;
+    await addTask({
+      title,
+      description: '',
+      completed: false,
+      due_date: dueDate ? new Date(dueDate) : undefined,
+    } as Omit<Task, 'id' | 'created_at'>);
+    setTitle('');
+    setDueDate('');
+  };
+
+  const startEdit = (task: Task) => {
+    setEditingId(task.id);
+    setEditTitle(task.title);
+    setEditDueDate(task.due_date ? task.due_date.toString().slice(0, 10) : '');
+  };
+
+  const saveEdit = async () => {
+    if (!editingId) return;
+    await updateTask(editingId, {
+      title: editTitle,
+      due_date: editDueDate ? new Date(editDueDate) : undefined,
+    });
+    setEditingId(null);
+  };
+
+  return (
+    <div className="p-6 space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold text-gray-900 mb-4">Tasks</h1>
+        <div className="flex flex-col sm:flex-row gap-3 mb-6">
+          <input
+            type="text"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder="Task title"
+            className="flex-1 border border-gray-300 rounded-lg px-3 py-2"
+          />
+          <input
+            type="date"
+            value={dueDate}
+            onChange={(e) => setDueDate(e.target.value)}
+            className="border border-gray-300 rounded-lg px-3 py-2"
+          />
+          <button
+            onClick={handleAdd}
+            className="bg-indigo-600 text-white px-4 py-2 rounded-lg flex items-center gap-2"
+          >
+            <Plus className="w-4 h-4" /> Add
+          </button>
+        </div>
+      </div>
+      <ul className="space-y-2">
+        {tasks.map((task) => (
+          <li
+            key={task.id}
+            className="flex items-center justify-between bg-white border border-gray-200 rounded-lg p-4"
+          >
+            {editingId === task.id ? (
+              <div className="flex-1 flex flex-col sm:flex-row gap-2">
+                <input
+                  value={editTitle}
+                  onChange={(e) => setEditTitle(e.target.value)}
+                  className="flex-1 border border-gray-300 rounded-lg px-3 py-2"
+                />
+                <input
+                  type="date"
+                  value={editDueDate}
+                  onChange={(e) => setEditDueDate(e.target.value)}
+                  className="border border-gray-300 rounded-lg px-3 py-2"
+                />
+                <button
+                  onClick={saveEdit}
+                  className="bg-indigo-600 text-white px-3 rounded-lg"
+                >
+                  Save
+                </button>
+              </div>
+            ) : (
+              <div className="flex items-center gap-3 flex-1">
+                <input
+                  type="checkbox"
+                  checked={task.completed}
+                  onChange={() => updateTask(task.id, { completed: !task.completed })}
+                  className="form-checkbox h-5 w-5 text-indigo-600"
+                />
+                <div className="flex-1">
+                  <p className={task.completed ? 'line-through text-gray-500' : 'text-gray-900'}>
+                    {task.title}
+                  </p>
+                  {task.due_date && (
+                    <p className="text-sm text-gray-500">
+                      Due {new Date(task.due_date).toLocaleDateString()}
+                    </p>
+                  )}
+                </div>
+              </div>
+            )}
+            <div className="flex items-center gap-2 ml-4">
+              {editingId !== task.id && (
+                <button
+                  onClick={() => startEdit(task)}
+                  className="text-gray-500 hover:text-gray-700"
+                >
+                  <Pencil className="w-4 h-4" />
+                </button>
+              )}
+              <button
+                onClick={() => deleteTask(task.id)}
+                className="text-red-600 hover:text-red-800"
+              >
+                <Trash className="w-4 h-4" />
+              </button>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/hooks/usePomodoroTimer.ts
+++ b/src/hooks/usePomodoroTimer.ts
@@ -4,18 +4,18 @@ import { dbHelpers } from '../lib/supabase';
 
 export type TimerMode = 'pomodoro' | 'short_break' | 'long_break';
 
+const TIMER_DURATIONS: Record<TimerMode, number> = {
+  pomodoro: 25 * 60,
+  short_break: 5 * 60,
+  long_break: 15 * 60,
+};
+
 export function usePomodoroTimer(userId: string | undefined) {
   const [timeLeft, setTimeLeft] = useState(25 * 60); // 25 minutes in seconds
   const [isActive, setIsActive] = useState(false);
   const [mode, setMode] = useState<TimerMode>('pomodoro');
   const [currentSession, setCurrentSession] = useState<FocusSession | null>(null);
   const [completedSessions, setCompletedSessions] = useState(0);
-
-  const TIMER_DURATIONS = {
-    pomodoro: 25 * 60,
-    short_break: 5 * 60,
-    long_break: 15 * 60,
-  };
 
   // Start timer
   const startTimer = useCallback(async () => {

--- a/src/hooks/useTasks.ts
+++ b/src/hooks/useTasks.ts
@@ -1,0 +1,42 @@
+import { useState, useEffect } from 'react';
+import type { Task } from '../types';
+import { dbHelpers } from '../lib/supabase';
+
+export function useTasks(userId: string | undefined) {
+  const [tasks, setTasks] = useState<Task[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!userId) return;
+    const load = async () => {
+      setLoading(true);
+      try {
+        const data = await dbHelpers.getTasks(userId);
+        setTasks(data || []);
+      } catch (err) {
+        console.error('Failed to load tasks:', err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, [userId]);
+
+  const addTask = async (task: Omit<Task, 'id' | 'created_at'>) => {
+    if (!userId) return;
+    const newTask = await dbHelpers.createTask({ ...task, user_id: userId });
+    setTasks((prev) => [...prev, newTask]);
+  };
+
+  const updateTask = async (id: string, updates: Partial<Task>) => {
+    const updated = await dbHelpers.updateTask(id, updates);
+    setTasks((prev) => prev.map((t) => (t.id === id ? updated : t)));
+  };
+
+  const deleteTask = async (id: string) => {
+    await dbHelpers.deleteTask(id);
+    setTasks((prev) => prev.filter((t) => t.id !== id));
+  };
+
+  return { tasks, loading, addTask, updateTask, deleteTask };
+}

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,4 +1,5 @@
 import { createClient } from '@supabase/supabase-js';
+import type { Activity, FocusSession, Goal, Task } from '../types';
 
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
 const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
@@ -96,7 +97,47 @@ export const dbHelpers = {
       .select('*')
       .eq('user_id', userId)
       .order('created_at', { ascending: false });
-    
+
+    if (error) throw error;
+    return data;
+  },
+
+  // Tasks
+  async createTask(task: Omit<Task, 'id' | 'created_at'> & { user_id: string }) {
+    const { data, error } = await supabase
+      .from('tasks')
+      .insert([task])
+      .select()
+      .single();
+
+    if (error) throw error;
+    return data;
+  },
+
+  async updateTask(id: string, updates: Partial<Task>) {
+    const { data, error } = await supabase
+      .from('tasks')
+      .update(updates)
+      .eq('id', id)
+      .select()
+      .single();
+
+    if (error) throw error;
+    return data;
+  },
+
+  async deleteTask(id: string) {
+    const { error } = await supabase.from('tasks').delete().eq('id', id);
+    if (error) throw error;
+  },
+
+  async getTasks(userId: string) {
+    const { data, error } = await supabase
+      .from('tasks')
+      .select('*')
+      .eq('user_id', userId)
+      .order('due_date', { ascending: true });
+
     if (error) throw error;
     return data;
   }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -30,6 +30,15 @@ export interface Goal {
   created_at: Date;
 }
 
+export interface Task {
+  id: string;
+  title: string;
+  description?: string;
+  completed: boolean;
+  due_date?: Date;
+  created_at: Date;
+}
+
 export interface DailyStats {
   date: string;
   total_productive_time: number;

--- a/supabase/migrations/20250731175610_create_tasks.sql
+++ b/supabase/migrations/20250731175610_create_tasks.sql
@@ -1,0 +1,58 @@
+/*
+  # Create tasks table
+
+  1. New Tables
+    - `tasks`
+      - `id` (uuid, primary key)
+      - `user_id` (uuid, foreign key to auth.users)
+      - `title` (text) - task title
+      - `description` (text, optional) - task details
+      - `completed` (boolean) - whether the task is done
+      - `due_date` (date, optional) - due date
+      - `created_at` (timestamptz) - when the task was created
+
+  2. Security
+    - Enable RLS on `tasks` table
+    - Add policies for authenticated users to manage their own data
+*/
+
+CREATE TABLE IF NOT EXISTS tasks (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  title text NOT NULL,
+  description text,
+  completed boolean NOT NULL DEFAULT false,
+  due_date date,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE tasks ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can read own tasks" 
+  ON tasks
+  FOR SELECT
+  TO authenticated
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can insert own tasks"
+  ON tasks
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can update own tasks"
+  ON tasks
+  FOR UPDATE
+  TO authenticated
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can delete own tasks"
+  ON tasks
+  FOR DELETE
+  TO authenticated
+  USING (auth.uid() = user_id);
+
+-- Indexes
+CREATE INDEX IF NOT EXISTS idx_tasks_user_id ON tasks(user_id);
+CREATE INDEX IF NOT EXISTS idx_tasks_due_date ON tasks(due_date);
+CREATE INDEX IF NOT EXISTS idx_tasks_completed ON tasks(completed);


### PR DESCRIPTION
## Summary
- add `Task` interface
- implement CRUD helpers for tasks in `supabase.ts`
- create `useTasks` hook for fetching and updating tasks
- add `Tasks` component with forms for task management
- wire up tasks view in sidebar and app routes
- include migration for `tasks` table
- fix lint warnings in Pomodoro timer hook

## Testing
- `npm run lint`
- `npm run build`
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_688beefc75808321aa44cbf14f30cf19