### PR TITLE
Add vitest setup and initial tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.53.0",
@@ -29,6 +30,11 @@
     "tailwindcss": "^3.4.1",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.3.0",
-    "vite": "^5.4.2"
+    "vite": "^5.4.2",
+    "vitest": "^1.4.0",
+    "@testing-library/react": "^14.2.2",
+    "@testing-library/jest-dom": "^6.4.2",
+    "@testing-library/user-event": "^14.5.1",
+    "jsdom": "^24.0.0"
   }
 }

--- a/src/components/Activities.test.tsx
+++ b/src/components/Activities.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+import { Activities } from './Activities';
+
+vi.mock('../hooks/useActivityTracker', () => ({
+  useActivityTracker: () => ({
+    activities: [
+      { id: '1', type: 'website', name: 'GitHub', url: 'github.com', category: 'Dev', duration: 60, timestamp: new Date(), productivity_score: 5 },
+      { id: '2', type: 'application', name: 'VS Code', category: 'Dev', duration: 120, timestamp: new Date(), productivity_score: 4 },
+    ],
+    isTracking: false,
+    startTracking: vi.fn(),
+    stopTracking: vi.fn(),
+  }),
+}));
+
+describe('Activities', () => {
+  it('shows activity count', () => {
+    render(<Activities userId="1" />);
+    expect(screen.getByText(/showing 2 of 2 activities/i)).toBeInTheDocument();
+  });
+
+  it('filters by search term', async () => {
+    render(<Activities userId="1" />);
+    await userEvent.type(screen.getByPlaceholderText(/search activities/i), 'code');
+    expect(screen.getByText(/showing 1 of 2 activities/i)).toBeInTheDocument();
+  });
+});

--- a/src/hooks/usePomodoroTimer.test.ts
+++ b/src/hooks/usePomodoroTimer.test.ts
@@ -1,0 +1,44 @@
+import { renderHook, act } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { usePomodoroTimer } from './usePomodoroTimer';
+
+vi.mock('../lib/supabase', () => ({
+  dbHelpers: {
+    createFocusSession: vi.fn().mockResolvedValue({ id: '1' }),
+    updateFocusSession: vi.fn().mockResolvedValue({}),
+  },
+}));
+
+describe('usePomodoroTimer', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('starts and counts down', async () => {
+    const { result } = renderHook(() => usePomodoroTimer(undefined));
+
+    expect(result.current.timeLeft).toBe(25 * 60);
+    act(() => {
+      result.current.startTimer();
+    });
+    expect(result.current.isActive).toBe(true);
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(result.current.timeLeft).toBe(25 * 60 - 1);
+  });
+
+  it('switches modes', () => {
+    const { result } = renderHook(() => usePomodoroTimer(undefined));
+    act(() => {
+      result.current.switchMode('short_break');
+    });
+    expect(result.current.mode).toBe('short_break');
+    expect(result.current.timeLeft).toBe(5 * 60);
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,4 +7,8 @@ export default defineConfig({
   optimizeDeps: {
     exclude: ['lucide-react'],
   },
+  test: {
+    environment: 'jsdom',
+    setupFiles: './vitest.setup.ts',
+  },
 });

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';


### PR DESCRIPTION
## Summary
- configure vitest in Vite config
- add vitest, testing-library, and jsdom deps
- add initial hook and component tests
- expose `npm test` script and vitest setup file

## Testing
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_688bef071bdc8321a9e2c43f31399154