### PR TITLE
Fix Vitest configuration for global testing

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,5 +10,6 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     setupFiles: './vitest.setup.ts',
+    globals: true,
   },
 });

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,1 +1,1 @@
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/vitest';


### PR DESCRIPTION
## Summary
- use Vitest-specific jest-dom setup to access matchers
- enable Vitest globals for describe/it syntax

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68952850fe548321acea7c5346f3cbfe