### PR TITLE
feat: sync activities to supabase

### DIFF
--- a/chrome-extension/README.md
+++ b/chrome-extension/README.md
@@ -51,8 +51,8 @@ The extension automatically categorizes websites:
 ## Data Storage
 
 - All data is stored locally in Chrome's storage
-- No data is sent to external servers
-- Option to sync with main RizeTracker app (when configured)
+- No data is sent to external servers unless syncing is enabled
+- Option to sync activities to a Supabase backend (when configured)
 
 ## Permissions
 


### PR DESCRIPTION
## Summary
- sync extension activity logs to Supabase when configured
- document optional Supabase syncing in extension README

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6895379cfda083219d0190f01144b6a8