### PR TITLE
refactor: add explicit types for supabase helpers and hooks

### DIFF
--- a/src/components/Activities.tsx
+++ b/src/components/Activities.tsx
@@ -45,15 +45,21 @@ export function Activities({ userId }: ActivitiesProps) {
   };
 
   // Calculate category stats
-  const categoryStats = activities.reduce((acc, activity) => {
-    if (!acc[activity.category]) {
-      acc[activity.category] = { count: 0, totalTime: 0, avgProductivity: 0 };
-    }
-    acc[activity.category].count++;
-    acc[activity.category].totalTime += activity.duration;
-    acc[activity.category].avgProductivity += activity.productivity_score;
-    return acc;
-  }, {} as Record<string, { count: number; totalTime: number; avgProductivity: number }>);
+  const categoryStats = activities.reduce(
+    (
+      acc: Record<string, { count: number; totalTime: number; avgProductivity: number }>,
+      activity
+    ) => {
+      if (!acc[activity.category]) {
+        acc[activity.category] = { count: 0, totalTime: 0, avgProductivity: 0 };
+      }
+      acc[activity.category].count++;
+      acc[activity.category].totalTime += activity.duration;
+      acc[activity.category].avgProductivity += activity.productivity_score;
+      return acc;
+    },
+    {} as Record<string, { count: number; totalTime: number; avgProductivity: number }>
+  );
 
   Object.keys(categoryStats).forEach(category => {
     categoryStats[category].avgProductivity /= categoryStats[category].count;

--- a/src/hooks/useActivityTracker.ts
+++ b/src/hooks/useActivityTracker.ts
@@ -30,10 +30,11 @@ const DEMO_APPLICATIONS = import.meta.env.DEV
     ]
   : [];
 
-type IncomingActivity = Omit<Activity, 'timestamp'> & {
+export interface IncomingActivity
+  extends Omit<Activity, 'id' | 'timestamp'> {
   timestamp: string | Date;
   domain?: string;
-};
+}
 
 export function useActivityTracker(userId: string | undefined) {
   const [currentActivity, setCurrentActivity] = useState<Activity | null>(null);
@@ -43,7 +44,8 @@ export function useActivityTracker(userId: string | undefined) {
     (activity: IncomingActivity) => {
       const { timestamp, ...rest } = activity;
       const formatted: Activity = {
-        ...(rest as Omit<Activity, 'timestamp'>),
+        ...(rest as Activity),
+        id: crypto.randomUUID(),
         timestamp: timestamp instanceof Date ? timestamp : new Date(timestamp),
       };
 

--- a/src/hooks/usePomodoroTimer.ts
+++ b/src/hooks/usePomodoroTimer.ts
@@ -21,12 +21,14 @@ export function usePomodoroTimer(userId: string | undefined) {
   const startTimer = useCallback(async () => {
     setIsActive(true);
     
-    const session: Omit<FocusSession, 'id'> = {
+    const session: Omit<
+      FocusSession & { user_id: string },
+      'id' | 'end_time' | 'completed'
+    > = {
       type: mode,
       duration: TIMER_DURATIONS[mode],
-      completed: false,
       start_time: new Date(),
-      user_id: userId,
+      user_id: userId!,
     };
 
     if (userId) {

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,4 +1,5 @@
 import { createClient } from '@supabase/supabase-js';
+import { Activity, FocusSession, Goal } from '../types';
 
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
 const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
@@ -12,18 +13,22 @@ export const supabase = createClient(supabaseUrl, supabaseAnonKey);
 // Database helper functions
 export const dbHelpers = {
   // Activities
-  async createActivity(activity: Omit<Activity, 'id'>) {
+  async createActivity(activity: Omit<Activity & { user_id: string }, 'id'>) {
     const { data, error } = await supabase
       .from('activities')
       .insert([activity])
       .select()
       .single();
-    
+
     if (error) throw error;
-    return data;
+    return data as Activity;
   },
 
-  async getActivities(userId: string, startDate?: Date, endDate?: Date) {
+  async getActivities(
+    userId: string,
+    startDate?: Date,
+    endDate?: Date
+  ): Promise<Activity[]> {
     let query = supabase
       .from('activities')
       .select('*')
@@ -39,19 +44,21 @@ export const dbHelpers = {
 
     const { data, error } = await query;
     if (error) throw error;
-    return data;
+    return data as Activity[];
   },
 
   // Focus Sessions
-  async createFocusSession(session: Omit<FocusSession, 'id'>) {
+  async createFocusSession(
+    session: Omit<FocusSession & { user_id: string }, 'id' | 'end_time' | 'completed'>
+  ) {
     const { data, error } = await supabase
       .from('focus_sessions')
       .insert([session])
       .select()
       .single();
-    
+
     if (error) throw error;
-    return data;
+    return data as FocusSession;
   },
 
   async updateFocusSession(id: string, updates: Partial<FocusSession>) {
@@ -61,21 +68,23 @@ export const dbHelpers = {
       .eq('id', id)
       .select()
       .single();
-    
+
     if (error) throw error;
-    return data;
+    return data as FocusSession;
   },
 
   // Goals
-  async createGoal(goal: Omit<Goal, 'id'>) {
+  async createGoal(
+    goal: Omit<Goal & { user_id: string }, 'id' | 'progress' | 'created_at'>
+  ) {
     const { data, error } = await supabase
       .from('goals')
       .insert([goal])
       .select()
       .single();
-    
+
     if (error) throw error;
-    return data;
+    return data as Goal;
   },
 
   async updateGoal(id: string, updates: Partial<Goal>) {
@@ -85,19 +94,19 @@ export const dbHelpers = {
       .eq('id', id)
       .select()
       .single();
-    
+
     if (error) throw error;
-    return data;
+    return data as Goal;
   },
 
-  async getGoals(userId: string) {
+  async getGoals(userId: string): Promise<Goal[]> {
     const { data, error } = await supabase
       .from('goals')
       .select('*')
       .eq('user_id', userId)
       .order('created_at', { ascending: false });
-    
+
     if (error) throw error;
-    return data;
-  }
+    return data as Goal[];
+  },
 };


### PR DESCRIPTION
## Summary
- define domain types in Supabase helper functions
- tighten type signatures in Pomodoro and activity tracking hooks
- clarify category stats typing in Activities component

## Testing
- `npm test -- --run`
- `npm run lint`
- `npm run dev`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68954a3be2908321a85bc630383042f6