### PR TITLE
Add analytics dashboard and auth page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,35 @@
-tracker
+# RizeTracker Dashboard
+
+This project provides a web dashboard for the RizeTracker extension, offering activity tracking and productivity analytics.
+
+## Hosted Dashboard
+
+A live deployment is available at:
+
+https://example.com
+
+## Development
+
+```bash
+npm install
+npm run dev
+```
+
+## Environment Variables
+
+Configure Supabase credentials in a `.env` file or via your hosting provider:
+
+```
+VITE_SUPABASE_URL=your_supabase_project_url
+VITE_SUPABASE_ANON_KEY=your_supabase_anon_key
+```
+
+## Deployment
+
+The `src/` folder contains a Vite + React app that can be deployed to services like Vercel. Set the above environment variables in the hosting platform's settings before deploying.
+
+## Features
+
+- Supabase authentication so users log into the same account as the extension.
+- Analytics view with charts for activity over time, productivity scores, and Pomodoro completion stats.
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,10 @@
       "version": "0.0.0",
       "dependencies": {
         "@supabase/supabase-js": "^2.53.0",
+        "chart.js": "^4.5.0",
         "lucide-react": "^0.344.0",
         "react": "^18.3.1",
+        "react-chartjs-2": "^5.3.0",
         "react-dom": "^18.3.1"
       },
       "devDependencies": {
@@ -1121,6 +1123,12 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -2590,6 +2598,18 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/chart.js": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.0.tgz",
+      "integrity": "sha512-aYeC/jDgSEx8SHWZvANYMioYMZ2KX02W6f6uVfyteuCGcadDLcYVHdfdygsTQkQ4TKn5lghoojAsPj5pu0SnvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
       }
     },
     "node_modules/check-error": {
@@ -5426,6 +5446,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-chartjs-2": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-5.3.0.tgz",
+      "integrity": "sha512-UfZZFnDsERI3c3CZGxzvNJd02SHjaSJ8kgW1djn65H1KK8rehwTjyrRKOG3VTMG8wtHZ5rgAO5oTHtHi9GCCmw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "chart.js": "^4.1.1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-dom": {

--- a/package.json
+++ b/package.json
@@ -12,12 +12,17 @@
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.53.0",
+    "chart.js": "^4.5.0",
     "lucide-react": "^0.344.0",
     "react": "^18.3.1",
+    "react-chartjs-2": "^5.3.0",
     "react-dom": "^18.3.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",
+    "@testing-library/jest-dom": "^6.4.2",
+    "@testing-library/react": "^14.2.2",
+    "@testing-library/user-event": "^14.5.1",
     "@types/react": "^18.3.5",
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react": "^4.3.1",
@@ -26,15 +31,12 @@
     "eslint-plugin-react-hooks": "^5.1.0-rc.0",
     "eslint-plugin-react-refresh": "^0.4.11",
     "globals": "^15.9.0",
+    "jsdom": "^24.0.0",
     "postcss": "^8.4.35",
     "tailwindcss": "^3.4.1",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.3.0",
     "vite": "^5.4.2",
-    "vitest": "^1.4.0",
-    "@testing-library/react": "^14.2.2",
-    "@testing-library/jest-dom": "^6.4.2",
-    "@testing-library/user-event": "^14.5.1",
-    "jsdom": "^24.0.0"
+    "vitest": "^1.4.0"
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import { useState } from 'react';
 import { useAuth } from './hooks/useAuth';
-import { AuthForm } from './components/AuthForm';
+import { AuthPage } from './pages/AuthPage';
 import { Sidebar } from './components/Sidebar';
 import { Dashboard } from './components/Dashboard';
 import { FocusTimer } from './components/FocusTimer';
 import { Activities } from './components/Activities';
+import { Analytics } from './components/Analytics';
 
 function App() {
   const { user, loading } = useAuth();
@@ -23,7 +24,7 @@ function App() {
   }
 
   if (!user) {
-    return <AuthForm />;
+    return <AuthPage />;
   }
 
   const renderContent = () => {
@@ -42,12 +43,7 @@ function App() {
           </div>
         );
       case 'analytics':
-        return (
-          <div className="p-6">
-            <h1 className="text-2xl font-bold text-white mb-4">Analytics</h1>
-            <p className="text-gray-400">Advanced analytics coming soon...</p>
-          </div>
-        );
+        return <Analytics userId={user.id} />;
       case 'settings':
         return (
           <div className="p-6">

--- a/src/components/Analytics.tsx
+++ b/src/components/Analytics.tsx
@@ -1,0 +1,110 @@
+import React, { useEffect, useState } from 'react';
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Tooltip,
+  Legend,
+} from 'chart.js';
+import { Line } from 'react-chartjs-2';
+import { dbHelpers } from '../lib/supabase';
+import { ActivityStats, PomodoroStats } from '../types';
+
+ChartJS.register(
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Tooltip,
+  Legend,
+);
+
+interface AnalyticsProps {
+  userId: string;
+}
+
+export function Analytics({ userId }: AnalyticsProps) {
+  const [activityStats, setActivityStats] = useState<ActivityStats[]>([]);
+  const [pomodoroStats, setPomodoroStats] = useState<PomodoroStats[]>([]);
+
+  useEffect(() => {
+    dbHelpers
+      .getActivityStats(userId)
+      .then(setActivityStats)
+      .catch(console.error);
+    dbHelpers
+      .getPomodoroStats(userId)
+      .then(setPomodoroStats)
+      .catch(console.error);
+  }, [userId]);
+
+  const activityData = {
+    labels: activityStats.map((s) => s.date.split('T')[0]),
+    datasets: [
+      {
+        label: 'Total Activity (min)',
+        data: activityStats.map((s) => s.total_duration / 60),
+        borderColor: 'rgb(255,255,255)',
+        backgroundColor: 'rgba(255,255,255,0.3)',
+        yAxisID: 'y',
+      },
+      {
+        label: 'Avg Productivity',
+        data: activityStats.map((s) => s.average_productivity),
+        borderColor: 'rgb(156,163,175)',
+        backgroundColor: 'rgba(156,163,175,0.3)',
+        yAxisID: 'y1',
+      },
+    ],
+  };
+
+  const activityOptions = {
+    responsive: true,
+    scales: {
+      y: {
+        title: { display: true, text: 'Minutes' },
+      },
+      y1: {
+        position: 'right',
+        min: 0,
+        max: 5,
+        title: { display: true, text: 'Score' },
+        grid: { drawOnChartArea: false },
+      },
+    },
+  } as const;
+
+  const pomodoroData = {
+    labels: pomodoroStats.map((s) => s.date.split('T')[0]),
+    datasets: [
+      {
+        label: 'Completed Pomodoros',
+        data: pomodoroStats.map((s) => s.completed_sessions),
+        borderColor: 'rgb(74,222,128)',
+        backgroundColor: 'rgba(74,222,128,0.3)',
+      },
+    ],
+  };
+
+  return (
+    <div className="p-6 space-y-6">
+      <h1 className="text-2xl font-bold text-white">Analytics</h1>
+
+      <div className="bg-gray-900 rounded-xl border border-gray-700 p-6">
+        <h2 className="text-lg font-semibold mb-4 text-white">
+          Activity Over Time
+        </h2>
+        <Line data={activityData} options={activityOptions} />
+      </div>
+
+      <div className="bg-gray-900 rounded-xl border border-gray-700 p-6">
+        <h2 className="text-lg font-semibold mb-4 text-white">
+          Pomodoro Completion
+        </h2>
+        <Line data={pomodoroData} />
+      </div>
+    </div>
+  );
+}

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -109,4 +109,33 @@ export const dbHelpers = {
     if (error) throw error;
     return data as Goal[];
   },
+
+  async getActivityStats(userId: string) {
+    const { data, error } = await supabase
+      .from('activities')
+      .select(
+        "date:date_trunc('day', timestamp), total_duration:sum(duration), average_productivity:avg(productivity_score)"
+      )
+      .eq('user_id', userId)
+      .group('date')
+      .order('date');
+
+    if (error) throw error;
+    return data as { date: string; total_duration: number; average_productivity: number }[];
+  },
+
+  async getPomodoroStats(userId: string) {
+    const { data, error } = await supabase
+      .from('focus_sessions')
+      .select(
+        "date:date_trunc('day', start_time), completed_sessions:count(id)"
+      )
+      .eq('user_id', userId)
+      .eq('completed', true)
+      .group('date')
+      .order('date');
+
+    if (error) throw error;
+    return data as { date: string; completed_sessions: number }[];
+  },
 };

--- a/src/pages/AuthPage.tsx
+++ b/src/pages/AuthPage.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import { AuthForm } from '../components/AuthForm';
+
+export function AuthPage() {
+  return <AuthForm />;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -55,3 +55,14 @@ export interface UserSettings {
   notifications_enabled: boolean;
   auto_categorization: boolean;
 }
+
+export interface ActivityStats {
+  date: string;
+  total_duration: number;
+  average_productivity: number;
+}
+
+export interface PomodoroStats {
+  date: string;
+  completed_sessions: number;
+}


### PR DESCRIPTION
## Summary
- add Supabase-driven analytics charts for activity, productivity, and Pomodoro completion
- introduce AuthPage and analytics components
- document deployment and environment variables

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6895a4a17908832186fd91f4edb55110