### PR TITLE
feat(extension): sync activities with supabase

### DIFF
--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -15,7 +15,8 @@
     "https://*/*"
   ],
   "background": {
-    "service_worker": "background.js"
+    "service_worker": "background.js",
+    "type": "module"
   },
   "content_scripts": [
     {


### PR DESCRIPTION
## Summary
- initialize Supabase client in background service worker and restore session from storage
- sync recorded activities and Pomodoro sessions to Supabase; add login/logout handlers
- mark background worker as module to support imports

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6895a4cbbcfc83219230cae55a4a0cf1