### PR TITLE
Add Supabase auth flow for extension

### DIFF
--- a/chrome-extension/popup.html
+++ b/chrome-extension/popup.html
@@ -227,7 +227,18 @@
     <p>Productivity & Focus Extension</p>
   </div>
 
-  <div class="content">
+  <div class="content" id="auth-section" style="display:none;">
+    <div class="section">
+      <h3>Account</h3>
+      <input type="email" id="email" placeholder="Email" style="width:100%;padding:8px;margin-bottom:8px;">
+      <input type="password" id="password" placeholder="Password" style="width:100%;padding:8px;margin-bottom:8px;">
+      <button class="btn" id="sign-in-btn">Sign In</button>
+      <button class="btn secondary" id="sign-up-btn" style="margin-left:8px;">Sign Up</button>
+      <div id="auth-message" style="margin-top:8px;font-size:12px;color:#374151;"></div>
+    </div>
+  </div>
+
+  <div class="content" id="main-content" style="display:none;">
     <!-- Tracking Section -->
     <div class="section">
       <h3>Website Tracking</h3>
@@ -286,10 +297,11 @@
     </div>
   </div>
 
-  <div class="footer">
+  <div class="footer" id="main-footer" style="display:none;">
     <button class="footer-btn" id="open-dashboard">Open Full Dashboard</button>
   </div>
 
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.53.0/dist/umd/supabase.min.js"></script>
   <script src="popup.js"></script>
 </body>
 </html>

--- a/chrome-extension/popup.js
+++ b/chrome-extension/popup.js
@@ -1,16 +1,35 @@
 // Popup script for Chrome extension
+// Supabase client setup - replace with your project's credentials
+const SUPABASE_URL = 'https://YOUR_SUPABASE_URL';
+const SUPABASE_ANON_KEY = 'YOUR_SUPABASE_ANON_KEY';
+const sb = window.supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+  auth: {
+    persistSession: false,
+    autoRefreshToken: true,
+  },
+});
+
 let currentState = {
   isTracking: false,
   pomodoroState: {
     isActive: false,
     timeLeft: 25 * 60,
     mode: 'pomodoro',
-    completedSessions: 0
+    completedSessions: 0,
   },
-  currentTab: null
+  currentTab: null,
 };
 
 // DOM elements
+const authSection = document.getElementById('auth-section');
+const mainContent = document.getElementById('main-content');
+const mainFooter = document.getElementById('main-footer');
+const emailInput = document.getElementById('email');
+const passwordInput = document.getElementById('password');
+const signInBtn = document.getElementById('sign-in-btn');
+const signUpBtn = document.getElementById('sign-up-btn');
+const authMessage = document.getElementById('auth-message');
+
 const trackingDot = document.getElementById('tracking-dot');
 const trackingStatus = document.getElementById('tracking-status');
 const trackingToggle = document.getElementById('tracking-toggle');
@@ -32,10 +51,11 @@ const openDashboard = document.getElementById('open-dashboard');
 
 // Initialize popup
 document.addEventListener('DOMContentLoaded', async () => {
+  await initializeAuth();
   await loadCurrentState();
   updateUI();
   setupEventListeners();
-  
+
   // Update every second
   setInterval(updateUI, 1000);
 });
@@ -52,8 +72,69 @@ async function loadCurrentState() {
   });
 }
 
+// Initialize authentication
+async function initializeAuth() {
+  const { supabaseSession } = await chrome.storage.local.get(['supabaseSession']);
+  if (supabaseSession) {
+    const { data, error } = await sb.auth.setSession(supabaseSession);
+    if (!error && data.session) {
+      showMainContent();
+    } else {
+      await chrome.storage.local.remove(['supabaseSession', 'userId']);
+      showAuth();
+    }
+  } else {
+    showAuth();
+  }
+
+  sb.auth.onAuthStateChange(async (_event, session) => {
+    if (session) {
+      await chrome.storage.local.set({
+        supabaseSession: session,
+        userId: session.user.id,
+      });
+      showMainContent();
+    } else {
+      await chrome.storage.local.remove(['supabaseSession', 'userId']);
+      showAuth();
+    }
+  });
+}
+
+function showAuth() {
+  authSection.style.display = 'block';
+  mainContent.style.display = 'none';
+  mainFooter.style.display = 'none';
+}
+
+function showMainContent() {
+  authSection.style.display = 'none';
+  mainContent.style.display = 'block';
+  mainFooter.style.display = 'block';
+}
+
 // Setup event listeners
 function setupEventListeners() {
+  // Auth buttons
+  signInBtn.addEventListener('click', async (e) => {
+    e.preventDefault();
+    authMessage.textContent = '';
+    const email = emailInput.value;
+    const password = passwordInput.value;
+    const { error } = await sb.auth.signInWithPassword({ email, password });
+    if (error) authMessage.textContent = error.message;
+  });
+
+  signUpBtn.addEventListener('click', async (e) => {
+    e.preventDefault();
+    authMessage.textContent = '';
+    const email = emailInput.value;
+    const password = passwordInput.value;
+    const { error } = await sb.auth.signUp({ email, password });
+    if (error) authMessage.textContent = error.message;
+    else authMessage.textContent = 'Check your email to confirm sign up';
+  });
+
   // Tracking toggle
   trackingToggle.addEventListener('click', () => {
     const action = currentState.isTracking ? 'stopTracking' : 'startTracking';
@@ -61,6 +142,8 @@ function setupEventListeners() {
       if (response.success) {
         currentState.isTracking = !currentState.isTracking;
         updateUI();
+      } else if (response && response.error) {
+        alert(response.error);
       }
     });
   });


### PR DESCRIPTION
## Summary
- add email/password form to popup and initialize Supabase client
- persist Supabase session and user id in chrome storage with token refresh
- require valid session before tracking or syncing activities

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6895a720e6948321aa2234f848035822